### PR TITLE
Typo, code cosmetics, duplicate jquery selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Since this is a static webpage, you can just copy and paste the contents of this
 
 ### Adjust Mail template
 
-This app is available in German and Englisch. Therefore, there is one version of the content files (html, config and mailtemplate) for both languages. The path of the mail template can be configured in the config.json of the respective language directory.
+This app is available in German and English. Therefore, there is one version of the content files (html, config and mailtemplate) for both languages. The path of the mail template can be configured in the config.json of the respective language directory.
 
 The path that is specified under the `mail.template` property of the config.json is relative to the location of the `reservation-show.html` page., e.g. if you specify "mail.txt" as path, the mail template should be in the same directory as the html file.
 

--- a/de/index.html
+++ b/de/index.html
@@ -36,12 +36,12 @@
             <ul class="nav navbar-nav navbar-right">
               <li class="dropdown">
                 <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="language_dropdown_toggle">
-                  <img src="../images/lang/flag_de.gif"/>
-                  <span class="caret"></span></a></a>
+                  <img alt="Sprache Deutsch Flagge" src="../images/lang/flag_de.gif"/>
+                  <span class="caret"></span></a>
                 <ul class="dropdown-menu">
                   <li>
                     <a href="../en/index.html" id="language_en"
-                      ><img src="../images/lang/flag_en.gif" /><span
+                      ><img alt="Sprache Englisch Flagge" src="../images/lang/flag_en.gif" /><span
                         style="padding-left:10px"
                         >Englisch</span
                       ></a
@@ -49,7 +49,7 @@
                   </li>
                   <li>
                     <a href="../de/index.html" id="language_de"
-                      ><img src="../images/lang/flag_de.gif" /><span
+                      ><img alt="Sprache Deutsch Flagge" src="../images/lang/flag_de.gif" /><span
                         style="padding-left:10px"
                         >Deutsch</span
                       ></a
@@ -93,7 +93,7 @@
         </div>
         <div class="row" style="margin-top: 5%">
           <div class="col-xs-4"></div>
-          <div class="col-xs-4" align="center">
+          <div class="col-xs-4" style="text-align: center">
             <a
               href="reservation-form.html"
               class="btn btn-primary active"

--- a/de/reservation-form.html
+++ b/de/reservation-form.html
@@ -36,12 +36,12 @@
               <ul class="nav navbar-nav navbar-right">
                 <li class="dropdown">
                   <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="language_dropdown_toggle">
-                    <img src="../images/lang/flag_de.gif"/>
+                    <img alt="Sprache Deutsch Flagge" src="../images/lang/flag_de.gif"/>
                     <span class="caret"></span></a>
                   <ul class="dropdown-menu">
                     <li>
                       <a href="../en/reservation-form.html" id="language_en"
-                        ><img src="../images/lang/flag_en.gif" /><span
+                        ><img alt="Sprache Englisch Flagge" src="../images/lang/flag_en.gif" /><span
                           style="padding-left:10px"
                           >Englisch</span
                         ></a
@@ -49,7 +49,7 @@
                     </li>
                     <li>
                       <a href="../de/reservation-form.html" id="language_de"
-                        ><img src="../images/lang/flag_de.gif" /><span
+                        ><img alt="Sprache Deutsch Flagge" src="../images/lang/flag_de.gif" /><span
                           style="padding-left:10px"
                           >Deutsch</span
                         ></a
@@ -408,7 +408,7 @@
 
 
           <div class="ef-formgroup form-group">
-            <h3>Kommentare</h3>
+            <h3><label for="comments">Kommentare</label></h3>
             <div class="col-xs-12" id="comments_error">
               <textarea
                 class="form-control"

--- a/de/reservation-show.html
+++ b/de/reservation-show.html
@@ -38,12 +38,12 @@
               <ul class="nav navbar-nav navbar-right">
                 <li class="dropdown">
                   <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="language_dropdown_toggle">
-                    <img src="../images/lang/flag_de.gif"/>
-                    <span class="caret"></span></a></a>
+                    <img alt="Sprache Deutsch Flagge" src="../images/lang/flag_de.gif"/>
+                    <span class="caret"></span></a>
                   <ul class="dropdown-menu">
                     <li>
                       <a href="../en/reservation-show.html" id="language_en"
-                        ><img src="../images/lang/flag_en.gif" /><span
+                        ><img alt="Sprache Englisch Flagge" src="../images/lang/flag_en.gif" /><span
                           style="padding-left:10px"
                           >Englisch</span
                         ></a
@@ -51,7 +51,7 @@
                     </li>
                     <li>
                       <a href="../de/reservation-show.html" id="language_de"
-                        ><img src="../images/lang/flag_de.gif" /><span
+                        ><img alt="Sprache Deutsch Flagge" src="../images/lang/flag_de.gif" /><span
                           style="padding-left:10px"
                           >Deutsch</span
                         ></a
@@ -79,7 +79,7 @@
           <p>
             Das ist eine Vorschau der E-Mail, die du verschicken musst. Die schwarzen Boxen (■■■■■■■) zeigen die Position an, an denen der geheime Code eingefügt werden muss. Dieser geheime Code wurde noch nicht veröffentlicht.
           </p>
-          <p><a href="#" class="btn btn-primary btn-sm" disabled>Schick die Mail noch nicht ab!</a></p>
+          <p><a href="#" class="btn btn-primary btn-sm">Schick die Mail noch nicht ab!</a></p>
           <p>
             Sobald der geheime Code veröffentlicht wurde, wird er automatisch geladen und an die richtigen Stellen eingefügt. Du musst diese Seite dafür nicht neu laden. Du findest alle Informationen die du brauchst, inklusive des geheimen Codes auch auf dem <a href="https://twitter.com/eurofurence"
             >Eurofurence Twitter Account</a

--- a/de/reservation-show.html
+++ b/de/reservation-show.html
@@ -79,7 +79,7 @@
           <p>
             Das ist eine Vorschau der E-Mail, die du verschicken musst. Die schwarzen Boxen (■■■■■■■) zeigen die Position an, an denen der geheime Code eingefügt werden muss. Dieser geheime Code wurde noch nicht veröffentlicht.
           </p>
-          <p><a href="#" class="btn btn-primary btn-sm">Schick die Mail noch nicht ab!</a></p>
+          <p><button class="btn btn-primary btn-sm" disabled>Schick die Mail noch nicht ab!</button></p>
           <p>
             Sobald der geheime Code veröffentlicht wurde, wird er automatisch geladen und an die richtigen Stellen eingefügt. Du musst diese Seite dafür nicht neu laden. Du findest alle Informationen die du brauchst, inklusive des geheimen Codes auch auf dem <a href="https://twitter.com/eurofurence"
             >Eurofurence Twitter Account</a

--- a/en/index.html
+++ b/en/index.html
@@ -36,13 +36,13 @@
             <ul class="nav navbar-nav navbar-right">
               <li class="dropdown">
                 <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="language_dropdown_toggle">
-                  <img src="../images/lang/flag_en.gif"/>
+                  <img alt="Language English Flag" src="../images/lang/flag_en.gif"/>
                   <span class="caret"></span
                 ></a>
                 <ul class="dropdown-menu">
                   <li>
                     <a href="../en/index.html" id="language_en"
-                      ><img src="../images/lang/flag_en.gif" /><span
+                      ><img alt="Language English Flag" src="../images/lang/flag_en.gif" /><span
                         style="padding-left:10px"
                         >English</span
                       ></a
@@ -50,7 +50,7 @@
                   </li>
                   <li>
                     <a href="../de/index.html" id="language_de"
-                      ><img src="../images/lang/flag_de.gif" /><span
+                      ><img alt="Language German Flag" src="../images/lang/flag_de.gif" /><span
                         style="padding-left:10px"
                         >German</span
                       ></a
@@ -104,7 +104,7 @@
         </div>
         <div class="row" style="margin-top: 5%">
           <div class="col-xs-4"></div>
-          <div class="col-xs-4" align="center">
+          <div class="col-xs-4" style="text-align: center">
             <a
               href="reservation-form.html"
               class="btn btn-primary active"

--- a/en/reservation-form.html
+++ b/en/reservation-form.html
@@ -36,13 +36,13 @@
             <ul class="nav navbar-nav navbar-right">
               <li class="dropdown">
                 <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="language_dropdown_toggle">
-                  <img src="../images/lang/flag_en.gif"/>
+                  <img alt="Language English Flag" src="../images/lang/flag_en.gif"/>
                   <span class="caret"></span
                 ></a>
                 <ul class="dropdown-menu">
                   <li>
                     <a href="../en/reservation-form.html" id="language_en"
-                      ><img src="../images/lang/flag_en.gif" /><span
+                      ><img alt="Language English Flag" src="../images/lang/flag_en.gif" /><span
                         style="padding-left:10px"
                         >English</span
                       ></a
@@ -50,7 +50,7 @@
                   </li>
                   <li>
                     <a href="../de/reservation-form.html" id="language_de"
-                      ><img src="../images/lang/flag_de.gif" /><span
+                      ><img alt="Language German Flag" src="../images/lang/flag_de.gif" /><span
                         style="padding-left:10px"
                         >German</span
                       ></a
@@ -415,7 +415,7 @@
 
 
           <div class="ef-formgroup form-group">
-            <h3>Comments</h3>
+            <h3><label for="comments">Comments</label></h3>
             <div class="col-xs-12" id="comments_error">
               <textarea
                 class="form-control"
@@ -447,7 +447,7 @@
                     type="hidden"
                     id="cannot_submit"
                     name="ignore"
-                    value="Du kannst die Email noch nicht generieren. Bitte fülle alle Pflichtfelder korrekt aus und setze den Haken bei &#39;Bestätigung&#39;, danach sollte es gehen. Dein Kommentar darf maximal 2000 Zeichen lang sein. Felder mit Validierungsfehlern sind rot markiert."
+                    value="You cannot generate the email yet. Please make sure you fill in all required fields correctly and accept the disclaimer, then try again. Comments are limited to 2000 characters. Invalid fields are marked in red."
                   />
                   <button type="submit" id="submitbutton" class="btn btn-primary">
                     Generate eMail

--- a/en/reservation-show.html
+++ b/en/reservation-show.html
@@ -38,13 +38,13 @@
               <ul class="nav navbar-nav navbar-right">
                 <li class="dropdown">
                   <a class="dropdown-toggle" data-toggle="dropdown" href="#" id="language_dropdown_toggle">
-                    <img src="../images/lang/flag_en.gif"/>
+                    <img alt="Language English Flag" src="../images/lang/flag_en.gif"/>
                     <span class="caret"></span
                   ></a>
                   <ul class="dropdown-menu">
                     <li>
                       <a href="../en/reservation-show.html" id="language_en"
-                        ><img src="../images/lang/flag_en.gif" /><span
+                        ><img alt="Language English Flag" src="../images/lang/flag_en.gif" /><span
                           style="padding-left:10px"
                           >English</span
                         ></a
@@ -52,7 +52,7 @@
                     </li>
                     <li>
                       <a href="../de/reservation-show.html" id="language_de"
-                        ><img src="../images/lang/flag_de.gif" /><span
+                        ><img alt="Language German Flag" src="../images/lang/flag_de.gif" /><span
                           style="padding-left:10px"
                           >German</span
                         ></a
@@ -84,7 +84,7 @@
             (■■■■■■■) represent the locations where the secret has to be
             inserted. However, the secret is not revealed yet.
           </p>
-          <p><a href="#" class="btn btn-primary btn-sm" disabled>Do not send the email yet!</a></p>
+          <p><a href="#" class="btn btn-primary btn-sm">Do not send the email yet!</a></p>
           <p>
             Once the secret is revealed, it is automatically loaded and added in
             the correct locations. You do not need to reload the page for that.

--- a/en/reservation-show.html
+++ b/en/reservation-show.html
@@ -84,7 +84,7 @@
             (■■■■■■■) represent the locations where the secret has to be
             inserted. However, the secret is not revealed yet.
           </p>
-          <p><a href="#" class="btn btn-primary btn-sm">Do not send the email yet!</a></p>
+          <p><button class="btn btn-primary btn-sm" disabled>Do not send the email yet!</button></p>
           <p>
             Once the secret is revealed, it is automatically loaded and added in
             the correct locations. You do not need to reload the page for that.

--- a/js/app.js
+++ b/js/app.js
@@ -97,21 +97,23 @@ function initializeDatepicker(dates) {
     datepickerLanguage = "en-GB";
   }
   var dateFormat = dates.dateFormat;
+  var arrivalElem = $("#arrival");
+  var departureElem = $("#departure");
 
-  if (!$("#arrival").val()) {
-    $("#arrival").val(dates.arrival.default);
+  if (!arrivalElem.val()) {
+    arrivalElem.val(dates.arrival.default);
   }
-  if (!$("#departure").val()) {
-    $("#departure").val(dates.departure.default);
+  if (!departureElem.val()) {
+    departureElem.val(dates.departure.default);
   }
 
-  $("#arrival").datepicker({
+  arrivalElem.datepicker({
     language: datepickerLanguage,
     format: dateFormat,
     startDate: dates.arrival.earliest,
     endDate: dates.arrival.latest
   });
-  $("#departure").datepicker({
+  departureElem.datepicker({
     language: datepickerLanguage,
     format: dateFormat,
     startDate: dates.departure.earliest,
@@ -305,7 +307,8 @@ function setupRoomTypes(roomTypes) {
 
   roomTypes.forEach(function(roomType, idx) {
     var i = idx + 1;
-    var element = $("#roomtype_template").clone();
+    var roomTypeTemplateElem = $("#roomtype_template");
+    var element = roomTypeTemplateElem.clone();
     element.attr("id", null);
     element.removeClass("template");
 
@@ -322,7 +325,7 @@ function setupRoomTypes(roomTypes) {
       element.find("#price_" + j).attr("id", "price" + i + "_" + j);
     }
 
-    $("#roomtype_template").before(element);
+    roomTypeTemplateElem.before(element);
   });
 }
 


### PR DESCRIPTION
Hope ya don't mind me creating a pull request

- readme typo, Englisch to English
- Removed stray <a> in german files
- Alt attribute for flags
- Align is deprecated, use style
- a can't be disabled
- removed duplicate jquery selectors